### PR TITLE
Resolved caching error when there is exactly x000 members in the PSAF discord

### DIFF
--- a/functions/playersCache.js
+++ b/functions/playersCache.js
@@ -10,10 +10,10 @@ export const getAllPlayers = async (guild_id) => {
     while(allPlayers.length === 0) {
       await sleep(5000)
       allPlayers = playersCache.get(guild_id)
-    }  
+    }
     return allPlayers
   }
-  
+
   playersCache.set(guild_id, [])
   let lastId = 0
   let totalPlayers = []
@@ -21,11 +21,13 @@ export const getAllPlayers = async (guild_id) => {
   let i=0
   do{
     const playersResp = await DiscordRequest(`/guilds/${guild_id}/members?limit=1000&after=${lastId}`, { method: 'GET' })
-    currentPlayers= await playersResp.json()
+    currentPlayers = await playersResp.json()
     totalPlayers = totalPlayers.concat(currentPlayers)
     i++
-    lastId = currentPlayers[currentPlayers.length-1].user.id
-  } while (currentPlayers.length === 1000 && i<5) // wont support more than 5000 players.
+    if (currentPlayers.length > 0) {
+      lastId = currentPlayers[currentPlayers.length - 1].user.id
+    }
+  } while (currentPlayers.length === 1000 && i < 10) // Max player count of 10,000
   playersCache.set(guild_id, totalPlayers)
   return totalPlayers
 }

--- a/functions/playersCache.js
+++ b/functions/playersCache.js
@@ -2,12 +2,12 @@ import NodeCache from "node-cache";
 import { DiscordRequest } from "../utils.js";
 import { sleep } from "./helpers.js";
 
-const playersCache = new NodeCache({ stdTTL: 60, checkperiod: 120, useClones: false})
+const playersCache = new NodeCache({ stdTTL: 60, checkperiod: 120, useClones: false })
 
 export const getAllPlayers = async (guild_id) => {
   let allPlayers = playersCache.get(guild_id)
-  if(allPlayers) {
-    while(allPlayers.length === 0) {
+  if (allPlayers) {
+    while (allPlayers.length === 0) {
       await sleep(5000)
       allPlayers = playersCache.get(guild_id)
     }
@@ -16,18 +16,23 @@ export const getAllPlayers = async (guild_id) => {
 
   playersCache.set(guild_id, [])
   let lastId = 0
-  let totalPlayers = []
+  let totalPlayers = []  // Properly initialize totalPlayers as an empty array
   let currentPlayers = []
-  let i=0
-  do{
+  let i = 0
+  do {
     const playersResp = await DiscordRequest(`/guilds/${guild_id}/members?limit=1000&after=${lastId}`, { method: 'GET' })
     currentPlayers = await playersResp.json()
-    totalPlayers = totalPlayers.concat(currentPlayers)
-    i++
-    if (currentPlayers.length > 0) {
-      lastId = currentPlayers[currentPlayers.length - 1].user.id
+    if (Array.isArray(currentPlayers)) {  // Ensure currentPlayers is an array before concatenating
+      totalPlayers = totalPlayers.concat(currentPlayers)
+      i++
+      if (currentPlayers.length > 0) {
+        lastId = currentPlayers[currentPlayers.length - 1].user.id
+      }
+    } else {
+      console.error('Unexpected response format:', currentPlayers)
+      break  // Exit the loop if the response is not an array
     }
-  } while (currentPlayers.length === 1000 && i < 10) // Max player count of 10,000
+  } while (currentPlayers.length === 1000 && i < 10) // Now supports up to 10,000 players
   playersCache.set(guild_id, totalPlayers)
   return totalPlayers
 }


### PR DESCRIPTION
Apologies for the weird looking diff, I think it's my linter going overboard.

This has already been implemented on the main discord for a few days now, although technically not tested since as soon as it was implemented, we got 3001 members.