### PR TITLE
pre-emptively adding transferList and lft collections, need to be added in mongo atlas pre-merge

### DIFF
--- a/functions/mongoClient.js
+++ b/functions/mongoClient.js
@@ -30,6 +30,8 @@ const mongoClient = (client) => {
         nationalTeams: psoDb.collection("NationalTeams"),
         nationalContracts: psoDb.collection("NationalContracts"),
         pendingPictures: psoDb.collection("PendingPictures"),
+        transferList: psoDb.collection("TransferList"),
+        lft: psoDb.collection("Lft"),
       }
       return await callback(collections)
     }


### PR DESCRIPTION
This is for the upcoming /transferlist and /lft commands. Just so it's noted somewhere, here's what those commands should look like:

/transferlist command restricted to managers only, and only able to list their own players

player @: 

hours: (Self-submit for now)

positions: (different from most common position that I use for cards and rating calculations)

buyout: (enforced that if this price is paid, they must sell for that price, also has to be an integer or float)

extra info: (Just an open space)


/unlist 

Player @: 




/lft

player @ not needed, already assumed with who is running the command

hours: (self-submit for now)

positions: 

extra info: (e.g 'only looking for Div 1 teams' , 'okay with being on the bench')


Then for the API route, the above information to be output in /transferlist and /lft endpoints, and then just with query parameters such as max buyout, team as well maybe?